### PR TITLE
Fix error in sign up API by removing the expires_in

### DIFF
--- a/app/controllers/concerns/doorkeeper_registrable.rb
+++ b/app/controllers/concerns/doorkeeper_registrable.rb
@@ -17,14 +17,12 @@ module DoorkeeperRegistrable
     access_token = Doorkeeper::AccessToken.create(resource_owner_id: user.id,
                                                   application_id: client_app.id,
                                                   refresh_token: generate_refresh_token,
-                                                  expries_in: Doorkeeper.configuration.access_token_expires_in.to_i,
                                                   scopes: '')
 
     {
       id: user.id,
       access_token: access_token.token,
       token_type: token_type,
-      expires_in: access_token.expires_in,
       refresh_token: access_token.refresh_token,
       created_at: access_token.created_at.to_time.to_i
     }

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -105,7 +105,7 @@ Doorkeeper.configure do
   # Access token expiration time (default: 2 hours).
   # If you want to disable expiration, set this to `nil`.
   #
-  access_token_expires_in nil
+  # access_token_expires_in nil
 
   # Assign custom TTL for access tokens. Will be used instead of access_token_expires_in
   # option if defined. In case the block returns `nil` value Doorkeeper fallbacks to


### PR DESCRIPTION
This pull request is fixing the error in sign up API by removing the access token expire in field.